### PR TITLE
WW-26

### DIFF
--- a/src/main/java/org/sagebionetworks/warehouse/workers/utils/AccessRecordUtils.java
+++ b/src/main/java/org/sagebionetworks/warehouse/workers/utils/AccessRecordUtils.java
@@ -17,6 +17,8 @@ public class AccessRecordUtils {
 	private static final String JAVA_CLIENT = "Synpase-Java-Client";
 	private static final String COMMAND_LINE_CLIENT = "synapsecommandlineclient";
 	private static final String ELB_CLIENT = "ELB-HealthChecker";
+	
+	public static final String NON_NORMALIZABLE_SIGNATURE = "NON_NORMALIZABLE";
 
 	private static final Pattern ENTITY_PATTERN = Pattern.compile("/entity/(syn\\d+|\\d+)");
 
@@ -32,7 +34,11 @@ public class AccessRecordUtils {
 		processed.setTimestamp(accessRecord.getTimestamp());
 		processed.setClient(getClient(accessRecord.getUserAgent()));
 		processed.setEntityId(getEntityId(accessRecord.getRequestURL()));
-		processed.setNormalizedMethodSignature(accessRecord.getMethod() + " " +PathNormalizer.normalizeMethodSignature(accessRecord.getRequestURL()) );
+		try {
+			processed.setNormalizedMethodSignature(accessRecord.getMethod() + " " +PathNormalizer.normalizeMethodSignature(accessRecord.getRequestURL()));
+		} catch (IllegalArgumentException e) {
+			processed.setNormalizedMethodSignature(NON_NORMALIZABLE_SIGNATURE);
+		}
 		return processed;
 	}
 

--- a/src/test/java/org/sagebionetworks/warehouse/workers/utils/AccessRecordUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/warehouse/workers/utils/AccessRecordUtilsTest.java
@@ -102,6 +102,14 @@ public class AccessRecordUtilsTest {
 
 		assertEquals(expected, AccessRecordUtils.processAccessRecord(ar));
 	}
+	
+	@Test
+	public void testNonNormalizableMethodSignature(){
+		AccessRecord accessRecord = AccessRecordTestUtil.createValidAccessRecord();
+		accessRecord.setRequestURL("/some/fake/path/");
+		ProcessedAccessRecord processedAccessRecord = AccessRecordUtils.processAccessRecord(accessRecord);
+		assertEquals(AccessRecordUtils.NON_NORMALIZABLE_SIGNATURE, processedAccessRecord.getNormalizedMethodSignature());
+	}
 
 	/*
 	 * getUserAccessRecord() Test


### PR DESCRIPTION
processAccessRecord will set the normalized method signature to 'NON_NORMALIZABLE' if the accessRecord contains an unrecognized request URL
